### PR TITLE
Fix completion items formats

### DIFF
--- a/autoload/asyncomplete/sources/nextword.vim
+++ b/autoload/asyncomplete/sources/nextword.vim
@@ -54,7 +54,7 @@ function! s:on_event(job_id, data, event)
 endfunction
 
 function! s:generate_items(candidates)
-    return map(a:candidates, '{"word": v:val, "kind": "[Nextword]"}')
+    return map(a:candidates, '{"word": v:val, "menu": "[Nextword]"}')
 endfunction
 
 function! s:stop_nextword()

--- a/autoload/asyncomplete/sources/nextword.vim
+++ b/autoload/asyncomplete/sources/nextword.vim
@@ -54,7 +54,7 @@ function! s:on_event(job_id, data, event)
 endfunction
 
 function! s:generate_items(candidates)
-    return map(a:candidates, '{"word": v:val, "menu": "[Nextword]"}')
+    return map(a:candidates, '{"word": v:val, "menu": "[nextword]"}')
 endfunction
 
 function! s:stop_nextword()


### PR DESCRIPTION
Hi. Thank you for asyncomplete-nextword.vim. It helps me everyday.

I made this pull request to fix completion items formats because many other asyncomplete.vim sources use `menu` with lowercase label for completion items. Other sources examples are:

* https://github.com/prabirshrestha/asyncomplete-buffer.vim/blob/018bcf0f712ce0fde3f1f2eaabd7004fccb2d34a/autoload/asyncomplete/sources/buffer.vim#L21
* https://github.com/prabirshrestha/asyncomplete-file.vim/blob/af59997d19c8f5ee65b448249a9cddc51560e243/autoload/asyncomplete/sources/file.vim#L5-L11
* https://github.com/prabirshrestha/asyncomplete-tags.vim/blob/041af0565f2c16634277cd29d2429c573af1dac4/autoload/asyncomplete/sources/tags.vim#L27
* https://github.com/prabirshrestha/asyncomplete-neosnippet.vim/blob/1b00832acabcd5fd443001b2ddd422e082a532b7/autoload/asyncomplete/sources/neosnippet.vim#L19


### Before

![screenshot_20210912_175101](https://user-images.githubusercontent.com/694547/132981854-2c8696e8-8149-43cb-9990-5f83d65c27f4.png)


### After

![screenshot_20210912_175143](https://user-images.githubusercontent.com/694547/132981860-5d8d4172-1a9f-4e0f-a3b1-1f617eed1d0e.png)

Best regards.